### PR TITLE
Restaurant Busyness

### DIFF
--- a/jumpstart/static/css/style.css
+++ b/jumpstart/static/css/style.css
@@ -47,11 +47,12 @@ body{
 }
 
 .datadog{
+    background-color: white;
     margin-top: 20px;
-    overflow: auto;
+    overflow: hidden;
     border: 8px #34495e solid;
     border-radius: 10px;
-    width: 760px;
+    width: 49.5%;
     height: 580px;
     float: right;
     margin-bottom: 4%;
@@ -60,9 +61,7 @@ body{
 .announcements{
     float: left;
     width: 50%;
-    padding-top: 22%;
     padding-left: 1%;
-    min-height: 840px;
     overflow: hidden;
     word-wrap: break-word;
 }

--- a/jumpstart/templates/index.html
+++ b/jumpstart/templates/index.html
@@ -33,6 +33,7 @@
             <div class="col-md-10" style="align-content: left; overflow: hidden;" align="left">
                 <!-- DataDog -->
                 <iframe class="datadog" id="datadog" scrolling="no" frameborder="0" src="https://p.datadoghq.com/sb/44f16805b-cab847d58c?tv_mode=true&theme=dark"></iframe>
+                <iframe class="datadog" id="datadog" scrolling="yes" frameborder="0" src="https://www.campusfood.cs.house/"></iframe>
                 <!-- Announcements -->
                 <div class="announcements">
                     <div class="panel panel-primary" style="overflow: hidden;">

--- a/jumpstart/templates/index.html
+++ b/jumpstart/templates/index.html
@@ -33,7 +33,7 @@
             <div class="col-md-10" style="align-content: left; overflow: hidden;" align="left">
                 <!-- DataDog -->
                 <iframe class="datadog" id="datadog" scrolling="no" frameborder="0" src="https://p.datadoghq.com/sb/44f16805b-cab847d58c?tv_mode=true&theme=dark"></iframe>
-                <iframe class="datadog" scrolling="yes" frameborder="0" src="https://www.campusfood.cs.house/"></iframe>
+                <iframe class="datadog" scrolling="no" frameborder="0" src="https://www.campusfood.cs.house/"></iframe>
                 <!-- Announcements -->
                 <div class="announcements">
                     <div class="panel panel-primary" style="overflow: hidden;">

--- a/jumpstart/templates/index.html
+++ b/jumpstart/templates/index.html
@@ -33,7 +33,7 @@
             <div class="col-md-10" style="align-content: left; overflow: hidden;" align="left">
                 <!-- DataDog -->
                 <iframe class="datadog" id="datadog" scrolling="no" frameborder="0" src="https://p.datadoghq.com/sb/44f16805b-cab847d58c?tv_mode=true&theme=dark"></iframe>
-                <iframe class="datadog" id="datadog" scrolling="yes" frameborder="0" src="https://www.campusfood.cs.house/"></iframe>
+                <iframe class="datadog" scrolling="yes" frameborder="0" src="https://www.campusfood.cs.house/"></iframe>
                 <!-- Announcements -->
                 <div class="announcements">
                     <div class="panel panel-primary" style="overflow: hidden;">


### PR DESCRIPTION
Adds a second iframe that shows the density of dining locations around the RIT campus and makes some CSS edits for the new design.

Screenshot:

![image](https://user-images.githubusercontent.com/19361215/133863206-3d8a3c60-6757-4898-9799-497f8bb211b0.png)